### PR TITLE
fix readme example image link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@
 
 4. **voila! color-coded console output**
 
-	![logboom colored console output](example.png)
+	![logboom colored console output](https://github.com/team-enceladus/logboom/blob/master/example.png?raw=true)
 
 5. **you also get a color-free `example.log` text file**
 


### PR DESCRIPTION
 - make link absolute to github storage, because the relative in-project link doesn't work on the npm page